### PR TITLE
Feature HMAC signature webhook security

### DIFF
--- a/__tests__/integration/webhook.test.js
+++ b/__tests__/integration/webhook.test.js
@@ -1,17 +1,63 @@
 import Status from "app/constants/status"
 import Config from "app/config"
+import Hmac from "app/utils/hmac"
+import MockHashgraphResponse from 'mocks/static/hashgraph'
 import axios from "axios"
 
 const { webhookUrl } = Config
 
-test("Check external '/api/status' returns a valid response, is it ready to be used?", async () => {
+test("Check webhook cannot consumed with a GET request", async () => {
 
   if (!webhookUrl) {
     console.warn("Skipping test as 'WEBHOOK_URL' not found in environment, for these tests to pass your external service needs to be redeployed");
     return
   }
 
-  const response = await axios.post(webhookUrl)
+  await expect(axios.get(webhookUrl)).rejects.toThrow("Request failed with status code 405");
+})
 
-  expect(response.status).toBe(Status.OK)
+test("Check webhook has been hit, if a signature does not exist, return 400", async () => {
+
+  if (!webhookUrl) {
+    console.warn("Skipping test as 'WEBHOOK_URL' not found in environment, for these tests to pass your external service needs to be redeployed");
+    return
+  }
+
+  await expect(axios.post(webhookUrl)).rejects.toThrow("Request failed with status code 400");
+})
+
+test("Check webhook has been hit, with a bad signature", async () => {
+
+  if (!webhookUrl) {
+    console.warn("Skipping test as 'WEBHOOK_URL' not found in environment, for these tests to pass your external service needs to be redeployed");
+    return
+  }
+
+  await expect(
+    axios.post(webhookUrl, {}, {
+      headers: {
+        'x-signature': '123'
+      }
+    })
+  ).rejects.toThrow("Request failed with status code 400");
+})
+
+test("Check webhook has been hit, with a good signature and body", async () => {
+
+  if (!webhookUrl) {
+    console.warn("Skipping test as 'WEBHOOK_URL' not found in environment, for these tests to pass your external service needs to be redeployed");
+    return
+  }
+
+  const { consensusMessageResponse } = MockHashgraphResponse
+  const mockResponseAsString = JSON.stringify(consensusMessageResponse)
+  const config = {
+    headers: {
+      'x-signature': Hmac.generateHash(mockResponseAsString)
+    }
+  }
+
+  const response = await axios.post(webhookUrl, consensusMessageResponse, config)
+
+  await expect(response.status).toBe(Status.OK);
 })

--- a/__tests__/unit/hmac.test.js
+++ b/__tests__/unit/hmac.test.js
@@ -1,0 +1,24 @@
+import Hmac from "app/utils/hmac"
+import MockHashgraphResponse from 'mocks/static/hashgraph'
+
+const { consensusMessageResponse } = MockHashgraphResponse
+const mockResponseAsString = JSON.stringify(consensusMessageResponse)
+
+test("Generate a HMAC signature using a json string", () => {
+  const hmac = Hmac.generateHash(mockResponseAsString)
+
+	expect(typeof hmac).toBe("string")
+})
+
+test("Expect exception when hash is generateHash where the payload is not a string", () => {
+  expect(() => Hmac.generateHash(consensusMessageResponse))
+    .toThrow('Your payload object must be converted in to a string');
+})
+
+
+test("Generate a HMAC signature then validate signature hash", () => {
+  const hmac = Hmac.generateHash(mockResponseAsString)
+  const isSignatureValid = Hmac.validateSignature(mockResponseAsString, hmac)
+
+  expect(isSignatureValid).toBe(true)
+})

--- a/app/handler/exampleWebhookHandler.js
+++ b/app/handler/exampleWebhookHandler.js
@@ -6,7 +6,7 @@ async function ExampleWebhookHandler(req, res) {
 		"Example webhook handler for sending consensus responses to your app."
 	)
 
-	const signature = req.headers['x-signature']
+	const signature = req.headers["x-signature"]
 
 	if (!signature) {
 		return Response.badRequest(res)

--- a/app/handler/exampleWebhookHandler.js
+++ b/app/handler/exampleWebhookHandler.js
@@ -1,9 +1,24 @@
 import Response from "app/response"
+import Hmac from "app/utils/hmac"
 
 async function ExampleWebhookHandler(req, res) {
 	console.log(
 		"Example webhook handler for sending consensus responses to your app."
 	)
+
+	const signature = req.headers['x-signature']
+
+	if (!signature) {
+		return Response.badRequest(res)
+	}
+
+	const stringifyData = JSON.stringify(req.body)
+	const isSignatureValid = Hmac.validateSignature(stringifyData, signature)
+
+	if (!isSignatureValid) {
+		return Response.badRequest(res)
+	}
+
 	Response.json(res, req.body)
 }
 

--- a/app/response/index.js
+++ b/app/response/index.js
@@ -17,6 +17,10 @@ function unprocessibleEntity(res, errors) {
 	return res.status(Status.UNPROCESSIBLE_ENTITY).send({ errors })
 }
 
+function badRequest(res) {
+	return res.status(Status.BAD_REQUEST).send({})
+}
+
 function json(res, data) {
 	res.json({ data })
 }
@@ -25,5 +29,6 @@ export default {
 	methodNotAllowed,
 	unauthorised,
 	unprocessibleEntity,
+	badRequest,
 	json
 }

--- a/app/utils/hmac.js
+++ b/app/utils/hmac.js
@@ -1,0 +1,34 @@
+import Config from "app/config"
+import Crypto from "crypto"
+
+/*
+ * The webhook mechanism requires a HMAC hash to ensure the source of any
+ * consensus message, to quickly check for validity.
+ *
+ * This HMAC hash is sent in the 'x-signature' property in the header, when
+ * sent to the webhook URL.
+ *
+ * Unless the `x-api-key` has been compromised only the serverless client
+ * and the server will be able to duplicate the signature.
+ */
+
+function generateHash(payloadAsString) {
+  if (typeof payloadAsString !== "string") {
+    throw 'Your payload object must be converted in to a string'
+  }
+
+  return Crypto.createHmac('sha256', Config.authenticationKey)
+    .update(payloadAsString)
+    .digest('hex');
+}
+
+function validateSignature(payloadAsString, signature) {
+  const hash = generateHash(payloadAsString)
+
+  return hash === signature
+}
+
+export default {
+  generateHash,
+  validateSignature
+}

--- a/app/utils/hmac.js
+++ b/app/utils/hmac.js
@@ -13,22 +13,22 @@ import Crypto from "crypto"
  */
 
 function generateHash(payloadAsString) {
-  if (typeof payloadAsString !== "string") {
-    throw 'Your payload object must be converted in to a string'
-  }
+	if (typeof payloadAsString !== "string") {
+		throw "Your payload object must be converted in to a string"
+	}
 
-  return Crypto.createHmac('sha256', Config.authenticationKey)
-    .update(payloadAsString)
-    .digest('hex');
+	return Crypto.createHmac("sha256", Config.authenticationKey)
+		.update(payloadAsString)
+		.digest("hex")
 }
 
 function validateSignature(payloadAsString, signature) {
-  const hash = generateHash(payloadAsString)
+	const hash = generateHash(payloadAsString)
 
-  return hash === signature
+	return hash === signature
 }
 
 export default {
-  generateHash,
-  validateSignature
+	generateHash,
+	validateSignature
 }

--- a/app/utils/sendWebhookMessage.js
+++ b/app/utils/sendWebhookMessage.js
@@ -13,7 +13,7 @@ function sendWebhookMessage(data) {
 	const dataAsString = JSON.stringify(data)
 	const config = {
 		headers: {
-			'x-signature': Hmac.generateHash(dataAsString)
+			"x-signature": Hmac.generateHash(dataAsString)
 		}
 	}
 

--- a/app/utils/sendWebhookMessage.js
+++ b/app/utils/sendWebhookMessage.js
@@ -1,4 +1,5 @@
 import Config from "app/config"
+import Hmac from "app/utils/hmac"
 import axios from "axios"
 
 function sendWebhookMessage(data) {
@@ -9,8 +10,15 @@ function sendWebhookMessage(data) {
 		return
 	}
 
+	const dataAsString = JSON.stringify(data)
+	const config = {
+		headers: {
+			'x-signature': Hmac.generateHash(dataAsString)
+		}
+	}
+
 	try {
-		axios.post(webhookUrl, { data })
+		axios.post(webhookUrl, { data }, config)
 	} catch (e) {
 		console.error(e)
 	}


### PR DESCRIPTION
## Rationale

Add HMAC signature protection to the webhook mechanism, to prove that consensus messages are from the serverless client. Unless the API_SECRET_KEY has been compromised.

## HMAC signature

Every webhook request will have a **x-signature** value in the header this is a HMAC SHA256 signature of the payload and of the API_SECRET_KEY

## Tests and documentation

Tests are updated as well as expected states for the webhook route to conform to. The webhook should validate the signature with the request body, if the signature and payload fails verification return with a 400 (Bad Request). 